### PR TITLE
Refactor flashcard repository

### DIFF
--- a/lib/flashcard_repository.dart
+++ b/lib/flashcard_repository.dart
@@ -1,17 +1,18 @@
 import 'dart:convert';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:http/http.dart' as http;
 
 import 'flashcard_model.dart';
 
-class FlashcardRepository {
-  static List<Flashcard>? _cache;
+/// Interface for a flashcard data source.
+abstract class FlashcardDataSource {
+  Future<List<Flashcard>> loadAll();
+}
 
-  /// Load all flashcards from assets/words.json.
-  /// The result is cached after the first read.
-  static Future<List<Flashcard>> loadAll() async {
-    if (_cache != null) {
-      return _cache!;
-    }
+/// Load flashcards from the bundled JSON file.
+class LocalFlashcardDataSource implements FlashcardDataSource {
+  @override
+  Future<List<Flashcard>> loadAll() async {
     final jsonString = await rootBundle.loadString('assets/words.json');
     final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
     List<Flashcard> cards = [];
@@ -24,7 +25,58 @@ class FlashcardRepository {
         } catch (_) {}
       }
     }
-    _cache = cards;
     return cards;
+  }
+}
+
+/// Load flashcards from a remote HTTP endpoint.
+class RemoteFlashcardDataSource implements FlashcardDataSource {
+  final String url;
+  final http.Client _client;
+
+  RemoteFlashcardDataSource(this.url, {http.Client? client})
+      : _client = client ?? http.Client();
+
+  @override
+  Future<List<Flashcard>> loadAll() async {
+    final response = await _client.get(Uri.parse(url));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to load flashcards');
+    }
+    final List<dynamic> jsonData =
+        json.decode(response.body) as List<dynamic>;
+    List<Flashcard> cards = [];
+    for (var item in jsonData) {
+      if (item is Map<String, dynamic> &&
+          item['id'] != null &&
+          item['term'] != null) {
+        try {
+          cards.add(Flashcard.fromJson(item));
+        } catch (_) {}
+      }
+    }
+    return cards;
+  }
+}
+
+/// Repository that caches flashcards loaded from a data source.
+class FlashcardRepository {
+
+  static FlashcardDataSource _dataSource = LocalFlashcardDataSource();
+  static List<Flashcard>? _cache;
+
+  /// Replace the current data source and clear the cache.
+  static void setDataSource(FlashcardDataSource source) {
+    _dataSource = source;
+    _cache = null;
+  }
+
+  /// Load all flashcards. Results are cached after the first read.
+  static Future<List<Flashcard>> loadAll() async {
+    if (_cache != null) {
+      return _cache!;
+    }
+    _cache = await _dataSource.loadAll();
+    return _cache!;
   }
 }

--- a/lib/quiz_setup_screen.dart
+++ b/lib/quiz_setup_screen.dart
@@ -1,9 +1,9 @@
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
 
 import 'flashcard_model.dart';
+import 'flashcard_repository.dart';
 import 'quiz_in_progress_screen.dart';
 
 // Quiz source selection options
@@ -69,22 +69,6 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     }
   }
 
-  Future<List<Flashcard>> _loadAllFlashcards() async {
-    final String jsonString =
-        await DefaultAssetBundle.of(context).loadString('assets/words.json');
-    final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
-    List<Flashcard> cards = [];
-    for (var item in jsonData) {
-      if (item is Map<String, dynamic> &&
-          item['id'] != null &&
-          item['term'] != null) {
-        try {
-          cards.add(Flashcard.fromJson(item));
-        } catch (_) {}
-      }
-    }
-    return cards;
-  }
 
   Future<void> _startQuiz() async {
     debugPrint('--- Quiz Setup ---');
@@ -93,7 +77,7 @@ class _QuizSetupScreenState extends State<QuizSetupScreen> {
     debugPrint('quizType: $_quizType');
     debugPrint('stars: $_starFilter');
 
-    final allCards = await _loadAllFlashcards();
+    final allCards = await FlashcardRepository.loadAll();
     if (!mounted) return;
     allCards.shuffle(Random());
     final sessionWords = allCards.take(_questionCount).toList();

--- a/lib/tabs_content/favorites_tab_content.dart
+++ b/lib/tabs_content/favorites_tab_content.dart
@@ -1,10 +1,10 @@
 // lib/tabs_content/favorites_tab_content.dart
 
-import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../flashcard_model.dart';
 import '../app_view.dart';
+import '../flashcard_repository.dart';
 
 const String favoritesBoxName = 'favorites_box_v2';
 
@@ -41,34 +41,13 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
     });
 
     try {
-      final String jsonString =
-          await DefaultAssetBundle.of(context).loadString('assets/words.json');
-      final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
-      List<Flashcard> loadedCards = [];
-      for (var item in jsonData) {
-        try {
-          if (item is Map<String, dynamic> &&
-              item['id'] != null &&
-              item['id'].toString().toLowerCase() != 'nan' &&
-              item['term'] != null &&
-              item['term'].toString().toLowerCase() != 'nan' &&
-              item['importance'] != null &&
-              item['importance'].toString().toLowerCase() != 'nan') {
-            loadedCards.add(Flashcard.fromJson(item));
-          }
-        } catch (e) {
-          // print('Error parsing item in favorites load: ${item['id']}: $e');
-        }
-      }
+      final loadedCards = await FlashcardRepository.loadAll();
       if (!mounted) return;
       setState(() {
         _allFlashcards = loadedCards;
         _isInitialLoading = false;
       });
-      print(
-          "_allFlashcards loaded in FavoritesTab: ${_allFlashcards.length} items"); // デバッグ用
-    } catch (e) {
-      // print('Failed to load words.json for favorites tab: $e');
+    } catch (_) {
       if (!mounted) return;
       setState(() {
         _initialError = '単語データの読み込みに失敗しました。';
@@ -76,6 +55,7 @@ class _FavoritesTabContentState extends State<FavoritesTabContent> {
       });
     }
   }
+
 
   Widget _buildFavoriteStarsIndicator(String wordId) {
     final Map<dynamic, dynamic>? favoriteStatusRaw = _favoritesBox.get(wordId);

--- a/lib/tabs_content/history_tab_content.dart
+++ b/lib/tabs_content/history_tab_content.dart
@@ -1,12 +1,12 @@
 // lib/tabs_content/history_tab_content.dart
 
-import 'dart:convert'; // ← この行を追加
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart'; // 日時フォーマット用 (pubspec.yaml に intl パッケージを追加してください)
 import '../flashcard_model.dart';
 import '../app_view.dart';
 import '../history_entry_model.dart'; // 履歴エントリーモデルをインポート
+import '../flashcard_repository.dart';
 
 const String historyBoxName = 'history_box_v2';
 
@@ -33,7 +33,6 @@ class _HistoryTabContentState extends State<HistoryTabContent> {
     _loadAllFlashcards(); // words.json から全単語を読み込む (お気に入りタブと同様)
   }
 
-  // words.jsonから全単語情報をロードする (お気に入りタブの処理と同様)
   Future<void> _loadAllFlashcards() async {
     if (!mounted) return;
     setState(() {
@@ -41,34 +40,13 @@ class _HistoryTabContentState extends State<HistoryTabContent> {
       _initialError = null;
     });
     try {
-      final String jsonString =
-          await DefaultAssetBundle.of(context).loadString('assets/words.json');
-      final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
-      List<Flashcard> loadedCards = [];
-      for (var item in jsonData) {
-        try {
-          if (item is Map<String, dynamic> &&
-              item['id'] != null &&
-              item['id'].toString().toLowerCase() != 'nan' &&
-              item['term'] != null &&
-              item['term'].toString().toLowerCase() != 'nan' &&
-              item['importance'] != null &&
-              item['importance'].toString().toLowerCase() != 'nan') {
-            loadedCards.add(Flashcard.fromJson(item));
-          }
-        } catch (e) {
-          // print('Error parsing item in history load: ${item['id']}: $e');
-        }
-      }
+      final loadedCards = await FlashcardRepository.loadAll();
       if (!mounted) return;
       setState(() {
         _allFlashcards = loadedCards;
         _isInitialLoading = false;
       });
-      print(
-          "_allFlashcards loaded in HistoryTab: ${_allFlashcards.length} items");
-    } catch (e) {
-      // print('Failed to load words.json for history tab: $e');
+    } catch (_) {
       if (!mounted) return;
       setState(() {
         _initialError = '単語データの読み込みに失敗しました。';

--- a/lib/today_summary_screen.dart
+++ b/lib/today_summary_screen.dart
@@ -1,11 +1,10 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 
 import 'flashcard_model.dart';
+import 'flashcard_repository.dart';
 import 'history_entry_model.dart';
 import 'app_view.dart';
 
@@ -40,19 +39,7 @@ class _TodaySummaryScreenState extends State<TodaySummaryScreen> {
 
   Future<void> _loadAllFlashcards() async {
     try {
-      final jsonString =
-          await DefaultAssetBundle.of(context).loadString('assets/words.json');
-      final List<dynamic> jsonData = json.decode(jsonString) as List<dynamic>;
-      List<Flashcard> cards = [];
-      for (var item in jsonData) {
-        if (item is Map<String, dynamic> &&
-            item['id'] != null &&
-            item['term'] != null) {
-          try {
-            cards.add(Flashcard.fromJson(item));
-          } catch (_) {}
-        }
-      }
+      final cards = await FlashcardRepository.loadAll();
       if (!mounted) return;
       setState(() {
         _allFlashcards = cards;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   hive_flutter: ^1.1.0
   path_provider: ^2.0.11
   fl_chart: ^0.64.0
+  http: ^0.13.6
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- abstract flashcard loading with `FlashcardDataSource`
- implement local and remote data sources with caching
- update UI screens to use the repository instead of asset loading
- add `http` package for remote source

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68508b9c8418832ab8009af45a4e6334