### PR TITLE
Ensure theme prefs loaded before runApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ Future<void> main() async {
   await Hive.openBox<Map>('quiz_stats_box_v1');
 
   final themeProvider = ThemeProvider();
+  await themeProvider.loadAppPreferences();
 
   runApp(
     ChangeNotifierProvider(


### PR DESCRIPTION
## Summary
- load theme provider preferences before constructing the app

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ed10d0a0832a986ff04073c9c84f