### PR TITLE
Encrypt Hive boxes with stored key

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   path_provider: ^2.0.11
+  flutter_secure_storage: ^9.0.0
   fl_chart: ^0.64.0
   http: ^0.13.6
 


### PR DESCRIPTION
## Summary
- add `flutter_secure_storage` to manage a persistent key
- use `HiveAesCipher` for all Hive boxes
- migrate existing unencrypted boxes on startup

## Testing
- `flutter pub get` *(fails: flutter not installed)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850f18bb360832a862323532c4c6af2